### PR TITLE
More top tagger utilities

### DIFF
--- a/NtupleClass.C
+++ b/NtupleClass.C
@@ -69,20 +69,40 @@ void NtupleClass::Loop()
       nbytes += nb;
 
       myHisto->Fill(NJets);
+      
       // if (Cut(ientry) < 0) continue;
 
+      // check for number of hadronic tops
+      int hadWs = 0;
+      for ( unsigned int gpi=0; gpi < GenParticles->size() ; gpi++ ) 
+      {
+          int pdgid = abs( GenParticles_PdgId->at(gpi) ) ;
+          int momid = abs( GenParticles_ParentId->at(gpi) ) ;
+          int status = GenParticles_Status->at(gpi);
+          
+          if(status == 23 && momid == 24 && pdgid < 6)
+          {
+              // Should be the quarks from W decay
+              hadWs++;
+          }
+      }
 
+      // Only keep events with two hadronic top decays
+      if (hadWs != 4) continue;  
+
+      // Check whether event would pass the trigger requirement
+      
       // Try to get the hadronic tops in the event
       // genparticles seem to have a new ordering here, so make a dummy list
-      std::vector<int> mydummylist;
-      for(int d=0; d<GenParticles->size(); ++d)
-          mydummylist.push_back(d);
-/*
-      std::vector<TLorentzVector> hadtops = ttUtility::GetHadTopLVec(*GenParticles, *GenParticles_PdgId, mydummylist, *GenParticles_ParentIdx);
-      for (TLorentzVector hadtop : hadtops){
-          std::cout << hadtop.M() << ", " << hadtop.Pt() << std::endl;
-      }
-*/
+      //std::vector<int> mydummylist;
+      //for(int d=0; d<GenParticles->size(); ++d)
+      //    mydummylist.push_back(d);
+
+      //std::vector<TLorentzVector> hadtops = ttUtility::GetHadTopLVec(*GenParticles, *GenParticles_PdgId, mydummylist, *GenParticles_ParentIdx);
+      //for (TLorentzVector hadtop : hadtops){
+      //    std::cout << hadtop.M() << ", " << hadtop.Pt() << std::endl;
+      // }
+
       // Use helper function to create input list 
       // Create AK4 inputs object
       ttUtility::ConstAK4Inputs AK4Inputs = ttUtility::ConstAK4Inputs(*Jets, *Jets_bDiscriminatorCSV);

--- a/NtupleClass.C
+++ b/NtupleClass.C
@@ -87,7 +87,7 @@ void NtupleClass::Loop()
       // Create AK4 inputs object
       ttUtility::ConstAK4Inputs AK4Inputs = ttUtility::ConstAK4Inputs(*Jets, *Jets_bDiscriminatorCSV);
     
-
+      /*
       // stick all the subjets in one list for now (this is what the top tagger expects)
       std::vector<TLorentzVector> JetsAK8_subjets_all;
       for (std::vector<TLorentzVector> subjets : *JetsAK8_subjets)
@@ -95,7 +95,8 @@ void NtupleClass::Loop()
           for (TLorentzVector subjet : subjets)
               JetsAK8_subjets_all.push_back(subjet);
       }
-      
+      */
+
       // Create AK8 inputs object
       ttUtility::ConstAK8Inputs AK8Inputs = ttUtility::ConstAK8Inputs(
           *JetsAK8,
@@ -103,7 +104,7 @@ void NtupleClass::Loop()
           *JetsAK8_NsubjettinessTau2,
           *JetsAK8_NsubjettinessTau3,
           *JetsAK8_softDropMass,
-          JetsAK8_subjets_all    // These should be the subjets!
+          *JetsAK8_subjets    // These should be the subjets!
           );
       
       // Create jets constituents list combining AK4 and AK8 jets, these are used to construct top candiates

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The first step is to install opencv. If you are working locally on the lpc machi
 
 Once you have access to opencv, you can proceed to install the toptagger: 
 
-First check out the code:
+First check out the code. We are now using a branch on top of the StandaloneRelease_v1.0.1, so make sure to check that you have the correct branch. 
 ```
 git clone git@github.com:susy2015/TopTagger.git
 cd TopTagger
-git checkout StandaloneRelease_v1.0.1
+git checkout StandaloneUpdates
 ```
 
 Then configure the tagger:
@@ -39,7 +39,17 @@ make -j4
 Of course, if you are not on the lpc, you should update the OPENCVDIR to match your system.
 This created a shared library, libTopTagger.so that we can use with our simple scripts. 
 
-To make sure that we have access to the library, we should add its location to our path. A setup script was created during configuration for this purpose (CMSSW_8_0_28/src/TopTagger/TopTagger/test/taggerSetup.sh). Note that this is a bash script. If you use tcsh it will not work. I have provided a tcsh script for you to customize based on the first two lines of the bash script (i.e. location of opencv and location of the TopTagger code on your system). You can check that out from the Exploration repository and execute it instead of the taggerSetup.sh script. 
+If you previously checked out a different branch/tag, do the following to update: 
+```
+cd $CMSSW_BASE/src/TopTagger
+git fetch
+git checkout StandaloneUpdates
+cd TopTagger/test
+make -j4
+```
+There is no need to rerun the configure step. 
+
+To make sure that we have access to the created library, we should add its location to our path. A setup script was created during configuration for this purpose (CMSSW_8_0_28/src/TopTagger/TopTagger/test/taggerSetup.sh). Note that this is a bash script. If you use tcsh it will not work. I have provided a tcsh script for you to customize based on the first two lines of the bash script (i.e. location of opencv and location of the TopTagger code on your system). You can check that out from the Exploration repository and execute it instead of the taggerSetup.sh script. 
 
 ```
 cd $CMSSW_BASE/src
@@ -67,7 +77,7 @@ The Makefile currently assumes that you are in a CMSSW environment. If you set u
 
 To run: 
 ```
-./MyAnalysis
+./MyAnalysis myinputfile optional_outputfilename
 ```
-This will give a printout for each event containing the number of tops it found, and some information on each top. 
+This will give a printout for the first 10 event containing the number of tops it found, and some information on each top. 
 You can customize TopTagger.cfg to enable/disable certain top candidates, i.e. in the TTMBasicClusterAlgo block, set doTrijet/doDijet/doMonojet to true or false. 


### PR DESCRIPTION
The NtupleClass.C code now includes the following:
- finding hadronic tops and their decay daughters
- passing this information along to the top tagger
- Getting the list of all used AK4 and AK8 jets from the top tagger (including the AK4's that matched an AK8)
- Pass the vector of vector of subjets to the top tagger

Note that this requires that you get a newer top tagger release, to make sure the top tagger understands the vector of vector of subjets. See updated instructions in README.

I'm still looking into what genmatching tools come with the toptagger itself. More on that to come in an upcoming pull request. 